### PR TITLE
support constructing with no arguments, and removing last server

### DIFF
--- a/lib/hashring.js
+++ b/lib/hashring.js
@@ -29,6 +29,8 @@ function hashRing(args, algorithm, options){
       weights = args;
       nodes = Object.keys(args)
       break;
+    case '[object Undefined]':
+      break;
     case '[object Array]':
     default:
       nodes = args;
@@ -83,6 +85,7 @@ HashRing.generateRing = function(){
   }
           
   // Calculate our hash-ring
+  this.sortedKeys.length = 0;
   for(i = 0; i < len; i++){
     
     weight = 1;
@@ -198,8 +201,8 @@ HashRing.addServer = function(server, weights){
     }
   }
   // pushes one, or more servers to
+  Array.isArray(server) || (server = [server]);
   Array.prototype.push.apply(this.nodes,server);
-  this.sortedKeys.length = 0;
   
   // clear all old caches and regenerate
   this.ring = {};
@@ -221,6 +224,7 @@ HashRing.removeServer = function(server){
   if (this.weights[server]){
     delete this.weights[server];
   }
+
   // clear all old caches and regenerate
   this.ring = {};
   this.cache = {};

--- a/tests/hashring.test.js
+++ b/tests/hashring.test.js
@@ -39,6 +39,23 @@ module.exports = {
     Object.keys(ring.weights).should.have.length(0);
   }
 
+, 'Constructing with no arguments': function(){
+    var ring = new hashring();
+    
+    ring.nodes.should.have.length(0);
+    ring.sortedKeys.should.have.length(0);
+    Object.keys(ring.weights).should.have.length(0);
+  }
+
+, 'Adding server after zero-argument constructor': function(){
+    var ring = new hashring();
+    ring.addServer('192.168.0.102:11212');
+    
+    ring.nodes.should.have.length(1);
+    ring.sortedKeys.length.should.be.above(1);
+    Object.keys(ring.weights).should.have.length(0);
+  }
+
 , 'Looking up keys': function(){
     var ring = new hashring(['192.168.0.102:11212', '192.168.0.103:11212', '192.168.0.104:11212']);
     ring.nodes.indexOf(ring.getNode('foo')).should.be.above(-1);
@@ -76,6 +93,15 @@ module.exports = {
     var ring = new hashring(['192.168.0.102:11212', '192.168.0.103:11212', '192.168.0.104:11212']);
     ring.removeServer('192.168.0.102:11212');
     ring.nodes.indexOf('192.168.0.102:11212').should.equal(-1);
+  }
+
+, 'Removing last server': function(){
+    var ring = new hashring('192.168.0.102:11212');
+    ring.removeServer('192.168.0.102:11212');
+    
+    ring.nodes.should.have.length(0);
+    ring.sortedKeys.should.have.length(0);
+    Object.keys(ring.weights).should.have.length(0);
   }
   
   // kindly lended from `node-hash-ring` :)


### PR DESCRIPTION
There are currently failures when constructing a new hashring with no arguments, as well as when a final remaining server is removed.  This pull request simply adds some handling (and test cases) for these situations.
