### PR TITLE
Fixes typo when assigning weights from object args

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function HashRing(args, algorithm, options) {
             weights[i] = args[i];
         } else {
           if ('weight' in args[i]) {
-            weights[i] = args[i].weigth;
+            weights[i] = args[i].weight;
           }
 
           if ('vnodes' in args[i]) {


### PR DESCRIPTION
It currently uses 'weigth' instead of 'weight' when reading the property from the args object so it will be undefined if your arguments look like : new HashRing({ 'servername' : { weight: 20 } });
