### PR TITLE
Use `bindings` to properly load the binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var hashValue = require('./build/Release/hashvalue')
+var hashValue = require('bindings')('hashvalue.node')
   , SimpleCache = require("simple-lru-cache")
   , parse = require('connection-parse')
   , crypto = require('crypto');

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "http://github.com/3rd-Eden/node-hashring.git"
   },
   "dependencies": {
+    "bindings": "1.1.x",
     "connection-parse": "0.0.x",
     "nan": "0.3.x",
     "simple-lru-cache": "0.0.x"


### PR DESCRIPTION
Sometimes the binding file isn't outputted in
`build/Release/hashvalue.node`, but for example in
`build/Debug/hashvalue.node`. `bindings` module covers all the cases.
