### PR TITLE
upgrade nan to 0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "benchmark": "1.0.x",
     "devnull": "0.0.x",
-    "microtime": "0.3.x",
+    "microtime": "0.5.x",
     "mocha": "1.8.x",
     "should": "1.2.x"
   },


### PR DESCRIPTION
I got below trace when I `npm install hashring` at my mba, and `node -v` prints `v0.11.10`:

```
node_modules/hashring/node_modules/nan/nan.h:518:3: error: unknown type name 'uv_work_t'
```

I guess this is the 0.3.x nan is not available for now, then may I ask u merge this PR and `npm publish` to let  we can use this module at v0.11.x?

Thank you :P
