### PR TITLE
Update nan dependency to 1.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bindings": "1.2.x",
     "connection-parse": "0.0.x",
-    "nan": "1.5.x",
+    "nan": "^1.8.4",
     "simple-lru-cache": "0.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This is needed for compatibility with the latest io.js release(s).