### PR TITLE
Explicitly select files to ship to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "author": "Arnout Kazemier",
   "description": "A consistent hashring compatible with ketama hashing and python's hash_ring",
   "main": "./index.js",
+  "files": [
+    "index.js"
+  ],
   "keywords": [
     "hashring",
     "hash ring",


### PR DESCRIPTION
The `tests` directory is pretty big. This changes selects which files to publish explicitly. `npm` will automatically include README, LICENSE, and CHANGELOG files.

Before:

```
> npm i hashring@latest && du -sh node_modules/hashring && ls node_modules/hashring
hashring@3.2.0 node_modules/hashring
├── connection-parse@0.0.7
└── simple-lru-cache@0.0.2
4.7M    node_modules/hashring
CHANGELOG     LICENSE       Makefile      README.md     benchmarks/   doc/          index.js      node_modules/ package.json  tests/
```

After:

```
> npm i ~/Projects/node/libs/node-hashring && du -sh node_modules/hashring && ls node_modules/hashring
hashring@3.2.0 node_modules/hashring
├── connection-parse@0.0.7
└── simple-lru-cache@0.0.2
132K    node_modules/hashring
CHANGELOG     LICENSE       README.md     index.js      node_modules/ package.json
```
