### PR TITLE
Solve inconsistent hashing behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ HashRing.prototype.continuum = function generate() {
   servers.forEach(function each(server) {
     var percentage = server.weight / total
       , vnodes = self.vnodes[server.string] || self.vnode
-      , length = Math.floor(percentage * vnodes * servers.length)
+      , length = Math.round(percentage * vnodes * servers.length)
       , key
       , x;
 


### PR DESCRIPTION
In a dynamic cluster (adding and removing nodes), there is a chance when dividing we receive an infinite repeating result which floors to a value that would be less than it needs to be to maintain a consistent hash with a prior state (in which the dividing result is a full integer, or not repeating).

Using round here seems to resolve the issue.

Test case: create a cluster of 6, distribute keys, add a new pnode (total 7), redistribute keys, add a new pnode (total 8), redistribute keys and then run through all keys and check that they exist in the correct location (failure).

solves issue #43 
