### PR TITLE
Ignore tests dir when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules
+build
+coverage
+tests


### PR DESCRIPTION
We noticed the test fixtures were in our production docker container

```
$ du -k node_modules/* | awk '$1 > 2000' | sort -nr # 2MB
4700  node_modules/hashring
4608  node_modules/@shutterstock
4596  node_modules/hashring/tests
4576  node_modules/hashring/tests/fixtures
```

Currently npm publish is using your .gitignore since there is no .npmignore provided https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package


This pr adds an .npmignore (based on your .gitignore to keep the existing functionality, with the tests directory excluded) 